### PR TITLE
Honor credentials passed to controller constructors

### DIFF
--- a/ProvisioningAPILib/Controllers/CDRsController.php
+++ b/ProvisioningAPILib/Controllers/CDRsController.php
@@ -24,10 +24,10 @@ class CDRsController {
     /**
      * Constructor with authentication and configuration parameters
      */
-    function __construct($basicAuthUserName, $basicAuthPassword)
+    function __construct($basicAuthUserName = NULL, $basicAuthPassword = NULL)
     {
-        $this->basicAuthUserName = $basicAuthUserName;
-        $this->basicAuthPassword = $basicAuthPassword;
+        $this->basicAuthUserName = $basicAuthUserName ? $basicAuthUserName : Configuration::$BasicAuthUserName;
+        $this->basicAuthPassword = $basicAuthPassword ? $basicAuthPassword : Configuration::$BasicAuthPassword;
     }
 
     /**
@@ -51,7 +51,7 @@ class CDRsController {
         );
 
         //prepare API request
-        $request = Unirest::get($queryUrl, $headers, NULL, Configuration::$BasicAuthUserName, Configuration::$BasicAuthPassword);
+        $request = Unirest::get($queryUrl, $headers, NULL, $this->basicAuthUserName, $this->basicAuthPassword);
 
         //and invoke the API call request to fetch the response
         $response = $request->getResponse();
@@ -92,7 +92,7 @@ class CDRsController {
         );
 
         //prepare API request
-        $request = Unirest::get($queryUrl, $headers, NULL, Configuration::$BasicAuthUserName, Configuration::$BasicAuthPassword);
+        $request = Unirest::get($queryUrl, $headers, NULL, $this->basicAuthUserName, $this->basicAuthPassword);
 
         //and invoke the API call request to fetch the response
         $response = $request->getResponse();
@@ -136,7 +136,7 @@ class CDRsController {
         );
 
         //prepare API request
-        $request = Unirest::post($queryUrl, $headers, NULL, Configuration::$BasicAuthUserName, Configuration::$BasicAuthPassword);
+        $request = Unirest::post($queryUrl, $headers, NULL, $this->basicAuthUserName, $this->basicAuthPassword);
 
         //and invoke the API call request to fetch the response
         $response = $request->getResponse();

--- a/ProvisioningAPILib/Controllers/ConfigurationController.php
+++ b/ProvisioningAPILib/Controllers/ConfigurationController.php
@@ -24,10 +24,10 @@ class ConfigurationController {
     /**
      * Constructor with authentication and configuration parameters
      */
-    function __construct($basicAuthUserName, $basicAuthPassword)
+    function __construct($basicAuthUserName = NULL, $basicAuthPassword = NULL)
     {
-        $this->basicAuthUserName = $basicAuthUserName;
-        $this->basicAuthPassword = $basicAuthPassword;
+        $this->basicAuthUserName = $basicAuthUserName ? $basicAuthUserName : Configuration::$BasicAuthUserName;
+        $this->basicAuthPassword = $basicAuthPassword ? $basicAuthPassword : Configuration::$BasicAuthPassword;
     }
 
    /**
@@ -131,7 +131,7 @@ class ConfigurationController {
         $request = Unirest::post($queryUrl, $headers, createBody($didIds, $voiceUriId, $smsLinkGroupId, $faxUriId, $capacityGroupId, 
         $trunkId, $deliveryId, $srvLookup, $cliFormat, $cliValue, $srvLookup, $cliFormat, $cliValue,
         $cliPrivacy, $t38Enabled, $dtmf, $dtmfInbandMute, $codecs, $ringback, $dnisEnabled, $blockOrdinary, 
-        $blockCellular,$blockPayphone, $smsOutbound, $webRtcEnabled), Configuration::$BasicAuthUserName, Configuration::$BasicAuthPassword);
+        $blockCellular,$blockPayphone, $smsOutbound, $webRtcEnabled), $this->basicAuthUserName, $this->basicAuthPassword);
 
         //and invoke the API call request to fetch the response
         $response = $request->getResponse();
@@ -191,7 +191,7 @@ class ConfigurationController {
         );
 
         //prepare API request
-        $request = Unirest::get($queryUrl, $headers, NULL, Configuration::$BasicAuthUserName, Configuration::$BasicAuthPassword);
+        $request = Unirest::get($queryUrl, $headers, NULL, $this->basicAuthUserName, $this->basicAuthPassword);
 
         //and invoke the API call request to fetch the response
         $response = $request->getResponse();
@@ -225,7 +225,7 @@ class ConfigurationController {
         );
 
         //prepare API request
-        $request = Unirest::get($queryUrl, $headers, NULL, Configuration::$BasicAuthUserName, Configuration::$BasicAuthPassword);
+        $request = Unirest::get($queryUrl, $headers, NULL, $this->basicAuthUserName, $this->basicAuthPassword);
 
         //and invoke the API call request to fetch the response
         $response = $request->getResponse();
@@ -275,7 +275,7 @@ class ConfigurationController {
         );
 
         //prepare API request
-        $request = Unirest::get($queryUrl, $headers, NULL, Configuration::$BasicAuthUserName, Configuration::$BasicAuthPassword);
+        $request = Unirest::get($queryUrl, $headers, NULL, $this->basicAuthUserName, $this->basicAuthPassword);
 
         //and invoke the API call request to fetch the response
         $response = $request->getResponse();
@@ -317,7 +317,7 @@ class ConfigurationController {
         ));
 
         //prepare API request
-        $request = Unirest::put($queryUrl, $headers, $body, Configuration::$BasicAuthUserName, Configuration::$BasicAuthPassword);
+        $request = Unirest::put($queryUrl, $headers, $body, $this->basicAuthUserName, $this->basicAuthPassword);
 
         //and invoke the API call request to fetch the response
         $response = $request->getResponse();
@@ -377,7 +377,7 @@ class ConfigurationController {
         );
 
         //prepare API request
-        $request = Unirest::get($queryUrl, $headers, NULL, Configuration::$BasicAuthUserName, Configuration::$BasicAuthPassword);
+        $request = Unirest::get($queryUrl, $headers, NULL, $this->basicAuthUserName, $this->basicAuthPassword);
 
         //and invoke the API call request to fetch the response
         $response = $request->getResponse();
@@ -435,7 +435,7 @@ class ConfigurationController {
         ));
 
         //prepare API request
-        $request = Unirest::put($queryUrl, $headers, $body, Configuration::$BasicAuthUserName, Configuration::$BasicAuthPassword);
+        $request = Unirest::put($queryUrl, $headers, $body, $this->basicAuthUserName, $this->basicAuthPassword);
 
         //and invoke the API call request to fetch the response
         $response = $request->getResponse();
@@ -487,7 +487,7 @@ class ConfigurationController {
         ));
 
         //prepare API request
-        $request = Unirest::put($queryUrl, $headers, $body, Configuration::$BasicAuthUserName, Configuration::$BasicAuthPassword);
+        $request = Unirest::put($queryUrl, $headers, $body, $this->basicAuthUserName, $this->basicAuthPassword);
 
         //and invoke the API call request to fetch the response
         $response = $request->getResponse();
@@ -527,7 +527,7 @@ class ConfigurationController {
         );
 
         //prepare API request
-        $request = Unirest::delete($queryUrl, $headers, NULL, Configuration::$BasicAuthUserName, Configuration::$BasicAuthPassword);
+        $request = Unirest::delete($queryUrl, $headers, NULL, $this->basicAuthUserName, $this->basicAuthPassword);
 
         //and invoke the API call request to fetch the response
         $response = $request->getResponse();
@@ -589,7 +589,7 @@ class ConfigurationController {
         ));
 
         //prepare API request
-        $request = Unirest::put($queryUrl, $headers, $body, Configuration::$BasicAuthUserName, Configuration::$BasicAuthPassword);
+        $request = Unirest::put($queryUrl, $headers, $body, $this->basicAuthUserName, $this->basicAuthPassword);
 
         //and invoke the API call request to fetch the response
         $response = $request->getResponse();
@@ -629,7 +629,7 @@ class ConfigurationController {
         );
 
         //prepare API request
-        $request = Unirest::delete($queryUrl, $headers, NULL, Configuration::$BasicAuthUserName, Configuration::$BasicAuthPassword);
+        $request = Unirest::delete($queryUrl, $headers, NULL, $this->basicAuthUserName, $this->basicAuthPassword);
 
         //and invoke the API call request to fetch the response
         $response = $request->getResponse();
@@ -703,7 +703,7 @@ class ConfigurationController {
         ));
 
         //prepare API request
-        $request = Unirest::put($queryUrl, $headers, $body, Configuration::$BasicAuthUserName, Configuration::$BasicAuthPassword);
+        $request = Unirest::put($queryUrl, $headers, $body, $this->basicAuthUserName, $this->basicAuthPassword);
 
         //and invoke the API call request to fetch the response
         $response = $request->getResponse();
@@ -743,7 +743,7 @@ class ConfigurationController {
         );
 
         //prepare API request
-        $request = Unirest::delete($queryUrl, $headers, NULL, Configuration::$BasicAuthUserName, Configuration::$BasicAuthPassword);
+        $request = Unirest::delete($queryUrl, $headers, NULL, $this->basicAuthUserName, $this->basicAuthPassword);
 
         //and invoke the API call request to fetch the response
         $response = $request->getResponse();
@@ -781,7 +781,7 @@ class ConfigurationController {
         );
 
         //prepare API request
-        $request = Unirest::delete($queryUrl, $headers, NULL, Configuration::$BasicAuthUserName, Configuration::$BasicAuthPassword);
+        $request = Unirest::delete($queryUrl, $headers, NULL, $this->basicAuthUserName, $this->basicAuthPassword);
 
         //and invoke the API call request to fetch the response
         $response = $request->getResponse();
@@ -819,7 +819,7 @@ class ConfigurationController {
         );
 
         //prepare API request
-        $request = Unirest::delete($queryUrl, $headers, NULL, Configuration::$BasicAuthUserName, Configuration::$BasicAuthPassword);
+        $request = Unirest::delete($queryUrl, $headers, NULL, $this->basicAuthUserName, $this->basicAuthPassword);
 
         //and invoke the API call request to fetch the response
         $response = $request->getResponse();

--- a/ProvisioningAPILib/Controllers/InventoryController.php
+++ b/ProvisioningAPILib/Controllers/InventoryController.php
@@ -24,10 +24,10 @@ class InventoryController {
     /**
      * Constructor with authentication and configuration parameters
      */
-    function __construct($basicAuthUserName, $basicAuthPassword)
+    function __construct($basicAuthUserName = NULL, $basicAuthPassword = NULL)
     {
-        $this->basicAuthUserName = $basicAuthUserName;
-        $this->basicAuthPassword = $basicAuthPassword;
+        $this->basicAuthUserName = $basicAuthUserName ? $basicAuthUserName : Configuration::$BasicAuthUserName;
+        $this->basicAuthPassword = $basicAuthPassword ? $basicAuthPassword : Configuration::$BasicAuthPassword;
     }
 
     /**
@@ -70,7 +70,7 @@ class InventoryController {
         );
 
         //prepare API request
-        $request = Unirest::get($queryUrl, $headers, NULL, Configuration::$BasicAuthUserName, Configuration::$BasicAuthPassword);
+        $request = Unirest::get($queryUrl, $headers, NULL, $this->basicAuthUserName, $this->basicAuthPassword);
 
         //and invoke the API call request to fetch the response
         $response = $request->getResponse();
@@ -117,7 +117,7 @@ class InventoryController {
         );
 
         //prepare API request
-        $request = Unirest::get($queryUrl, $headers, NULL, Configuration::$BasicAuthUserName, Configuration::$BasicAuthPassword);
+        $request = Unirest::get($queryUrl, $headers, NULL, $this->basicAuthUserName, $this->basicAuthPassword);
 
         //and invoke the API call request to fetch the response
         $response = $request->getResponse();
@@ -151,7 +151,7 @@ class InventoryController {
         );
 
         //prepare API request
-        $request = Unirest::get($queryUrl, $headers, NULL, Configuration::$BasicAuthUserName, Configuration::$BasicAuthPassword);
+        $request = Unirest::get($queryUrl, $headers, NULL, $this->basicAuthUserName, $this->basicAuthPassword);
 
         //and invoke the API call request to fetch the response
         $response = $request->getResponse();
@@ -240,7 +240,7 @@ class InventoryController {
         );
 
         //prepare API request
-        $request = Unirest::get($queryUrl, $headers, NULL, Configuration::$BasicAuthUserName, Configuration::$BasicAuthPassword);
+        $request = Unirest::get($queryUrl, $headers, NULL, $this->basicAuthUserName, $this->basicAuthPassword);
 
         //and invoke the API call request to fetch the response
         $response = $request->getResponse();
@@ -311,7 +311,7 @@ class InventoryController {
         );
 
         //prepare API request
-        $request = Unirest::get($queryUrl, $headers, NULL, Configuration::$BasicAuthUserName, Configuration::$BasicAuthPassword);
+        $request = Unirest::get($queryUrl, $headers, NULL, $this->basicAuthUserName, $this->basicAuthPassword);
 
         //and invoke the API call request to fetch the response
         $response = $request->getResponse();
@@ -345,7 +345,7 @@ class InventoryController {
         );
 
         //prepare API request
-        $request = Unirest::get($queryUrl, $headers, NULL, Configuration::$BasicAuthUserName, Configuration::$BasicAuthPassword);
+        $request = Unirest::get($queryUrl, $headers, NULL, $this->basicAuthUserName, $this->basicAuthPassword);
 
         //and invoke the API call request to fetch the response
         $response = $request->getResponse();
@@ -379,7 +379,7 @@ class InventoryController {
         );
 
         //prepare API request
-        $request = Unirest::get($queryUrl, $headers, NULL, Configuration::$BasicAuthUserName, Configuration::$BasicAuthPassword);
+        $request = Unirest::get($queryUrl, $headers, NULL, $this->basicAuthUserName, $this->basicAuthPassword);
 
         //and invoke the API call request to fetch the response
         $response = $request->getResponse();
@@ -413,7 +413,7 @@ class InventoryController {
         );
 
         //prepare API request
-        $request = Unirest::get($queryUrl, $headers, NULL, Configuration::$BasicAuthUserName, Configuration::$BasicAuthPassword);
+        $request = Unirest::get($queryUrl, $headers, NULL, $this->basicAuthUserName, $this->basicAuthPassword);
 
         //and invoke the API call request to fetch the response
         $response = $request->getResponse();
@@ -454,7 +454,7 @@ class InventoryController {
         );
 
         //prepare API request
-        $request = Unirest::get($queryUrl, $headers, NULL, Configuration::$BasicAuthUserName, Configuration::$BasicAuthPassword);
+        $request = Unirest::get($queryUrl, $headers, NULL, $this->basicAuthUserName, $this->basicAuthPassword);
 
         //and invoke the API call request to fetch the response
         $response = $request->getResponse();
@@ -495,7 +495,7 @@ class InventoryController {
         );
 
         //prepare API request
-        $request = Unirest::get($queryUrl, $headers, NULL, Configuration::$BasicAuthUserName, Configuration::$BasicAuthPassword);
+        $request = Unirest::get($queryUrl, $headers, NULL, $this->basicAuthUserName, $this->basicAuthPassword);
 
         //and invoke the API call request to fetch the response
         $response = $request->getResponse();
@@ -536,7 +536,7 @@ class InventoryController {
         );
 
         //prepare API request
-        $request = Unirest::get($queryUrl, $headers, NULL, Configuration::$BasicAuthUserName, Configuration::$BasicAuthPassword);
+        $request = Unirest::get($queryUrl, $headers, NULL, $this->basicAuthUserName, $this->basicAuthPassword);
 
         //and invoke the API call request to fetch the response
         $response = $request->getResponse();

--- a/ProvisioningAPILib/Controllers/OrderingController.php
+++ b/ProvisioningAPILib/Controllers/OrderingController.php
@@ -24,10 +24,10 @@ class OrderingController {
     /**
      * Constructor with authentication and configuration parameters
      */
-    function __construct($basicAuthUserName, $basicAuthPassword)
+    function __construct($basicAuthUserName = NULL, $basicAuthPassword = NULL)
     {
-        $this->basicAuthUserName = $basicAuthUserName;
-        $this->basicAuthPassword = $basicAuthPassword;
+        $this->basicAuthUserName = $basicAuthUserName ? $basicAuthUserName : Configuration::$BasicAuthUserName;
+        $this->basicAuthPassword = $basicAuthPassword ? $basicAuthPassword : Configuration::$BasicAuthPassword;
     }
 
     /**
@@ -51,7 +51,7 @@ class OrderingController {
         );
 
         //prepare API request
-        $request = Unirest::get($queryUrl, $headers, NULL, Configuration::$BasicAuthUserName, Configuration::$BasicAuthPassword);
+        $request = Unirest::get($queryUrl, $headers, NULL, $this->basicAuthUserName, $this->basicAuthPassword);
 
         //and invoke the API call request to fetch the response
         $response = $request->getResponse();
@@ -88,7 +88,7 @@ class OrderingController {
         );
 
         //prepare API request
-        $request = Unirest::post($queryUrl, $headers, json_encode($didIds), Configuration::$BasicAuthUserName, Configuration::$BasicAuthPassword);
+        $request = Unirest::post($queryUrl, $headers, json_encode($didIds), $this->basicAuthUserName, $this->basicAuthPassword);
 
         //and invoke the API call request to fetch the response
         $response = $request->getResponse();
@@ -129,7 +129,7 @@ class OrderingController {
         $body = json_encode(array("customerReference" => $customerReference, "description" => $description));
 
         //prepare API request
-        $request = Unirest::put($queryUrl, $headers, $body, Configuration::$BasicAuthUserName, Configuration::$BasicAuthPassword);
+        $request = Unirest::put($queryUrl, $headers, $body, $this->basicAuthUserName, $this->basicAuthPassword);
 
         //and invoke the API call request to fetch the response
         $response = $request->getResponse();
@@ -181,7 +181,7 @@ class OrderingController {
         );
 
         //prepare API request
-        $request = Unirest::get($queryUrl, $headers, NULL, Configuration::$BasicAuthUserName, Configuration::$BasicAuthPassword);
+        $request = Unirest::get($queryUrl, $headers, NULL, $this->basicAuthUserName, $this->basicAuthPassword);
 
         //and invoke the API call request to fetch the response
         $response = $request->getResponse();
@@ -237,7 +237,7 @@ class OrderingController {
         );
 
         //prepare API request
-        $request = Unirest::get($queryUrl, $headers, NULL, Configuration::$BasicAuthUserName, Configuration::$BasicAuthPassword);
+        $request = Unirest::get($queryUrl, $headers, NULL, $this->basicAuthUserName, $this->basicAuthPassword);
 
         //and invoke the API call request to fetch the response
         $response = $request->getResponse();
@@ -278,7 +278,7 @@ class OrderingController {
         );
 
         //prepare API request
-        $request = Unirest::delete($queryUrl, $headers, NULL, Configuration::$BasicAuthUserName, Configuration::$BasicAuthPassword);
+        $request = Unirest::delete($queryUrl, $headers, NULL, $this->basicAuthUserName, $this->basicAuthPassword);
 
         //and invoke the API call request to fetch the response
         $response = $request->getResponse();
@@ -319,7 +319,7 @@ class OrderingController {
         );
 
         //prepare API request
-        $request = Unirest::get($queryUrl, $headers, NULL, Configuration::$BasicAuthUserName, Configuration::$BasicAuthPassword);
+        $request = Unirest::get($queryUrl, $headers, NULL, $this->basicAuthUserName, $this->basicAuthPassword);
 
         //and invoke the API call request to fetch the response
         $response = $request->getResponse();
@@ -405,7 +405,7 @@ class OrderingController {
 
 
         //prepare API request
-        $request = Unirest::post($queryUrl, $headers, createBody($cartIdentifier, $didGroupId, $zone, $creditPackageId, $quantity), Configuration::$BasicAuthUserName, Configuration::$BasicAuthPassword);
+        $request = Unirest::post($queryUrl, $headers, createBody($cartIdentifier, $didGroupId, $zone, $creditPackageId, $quantity), $this->basicAuthUserName, $this->basicAuthPassword);
 
         //and invoke the API call request to fetch the response
         $response = $request->getResponse();
@@ -459,7 +459,7 @@ class OrderingController {
         ));
 
         //prepare API request
-        $request = Unirest::put($queryUrl, $headers, $body, Configuration::$BasicAuthUserName, Configuration::$BasicAuthPassword);
+        $request = Unirest::put($queryUrl, $headers, $body, $this->basicAuthUserName, $this->basicAuthPassword);
 
         //and invoke the API call request to fetch the response
         $response = $request->getResponse();

--- a/ProvisioningAPILib/Controllers/RegulationController.php
+++ b/ProvisioningAPILib/Controllers/RegulationController.php
@@ -24,10 +24,10 @@ class RegulationController {
     /**
      * Constructor with authentication and configuration parameters
      */
-    function __construct($basicAuthUserName, $basicAuthPassword)
+    function __construct($basicAuthUserName = NULL, $basicAuthPassword = NULL)
     {
-        $this->basicAuthUserName = $basicAuthUserName;
-        $this->basicAuthPassword = $basicAuthPassword;
+        $this->basicAuthUserName = $basicAuthUserName ? $basicAuthUserName : Configuration::$BasicAuthUserName;
+        $this->basicAuthPassword = $basicAuthPassword ? $basicAuthPassword : Configuration::$BasicAuthPassword;
     }
 
     /**
@@ -97,7 +97,7 @@ class RegulationController {
         );
 
         //prepare API request
-        $request = Unirest::get($queryUrl, $headers, NULL, Configuration::$BasicAuthUserName, Configuration::$BasicAuthPassword);
+        $request = Unirest::get($queryUrl, $headers, NULL, $this->basicAuthUserName, $this->basicAuthPassword);
 
         //and invoke the API call request to fetch the response
         $response = $request->getResponse();
@@ -147,7 +147,7 @@ class RegulationController {
         );
 
         //prepare API request
-        $request = Unirest::get($queryUrl, $headers, NULL, Configuration::$BasicAuthUserName, Configuration::$BasicAuthPassword);
+        $request = Unirest::get($queryUrl, $headers, NULL, $this->basicAuthUserName, $this->basicAuthPassword);
 
         //and invoke the API call request to fetch the response
         $response = $request->getResponse();
@@ -184,7 +184,7 @@ class RegulationController {
         );
 
         //prepare API request
-        $request = Unirest::post($queryUrl, $headers, json_encode($didIds), Configuration::$BasicAuthUserName, Configuration::$BasicAuthPassword);
+        $request = Unirest::post($queryUrl, $headers, json_encode($didIds), $this->basicAuthUserName, $this->basicAuthPassword);
 
         //and invoke the API call request to fetch the response
         $response = $request->getResponse();
@@ -225,7 +225,7 @@ class RegulationController {
         );
 
         //prepare API request
-        $request = Unirest::delete($queryUrl, $headers, NULL, Configuration::$BasicAuthUserName, Configuration::$BasicAuthPassword);
+        $request = Unirest::delete($queryUrl, $headers, NULL, $this->basicAuthUserName, $this->basicAuthPassword);
 
         //and invoke the API call request to fetch the response
         $response = $request->getResponse();
@@ -273,7 +273,7 @@ class RegulationController {
         ));
 
         //prepare API request
-        $request = Unirest::post($queryUrl, $headers, $body, Configuration::$BasicAuthUserName, Configuration::$BasicAuthPassword);
+        $request = Unirest::post($queryUrl, $headers, $body, $this->basicAuthUserName, $this->basicAuthPassword);
 
         //and invoke the API call request to fetch the response
         $response = $request->getResponse();
@@ -315,7 +315,7 @@ class RegulationController {
         );
 
         //prepare API request
-        $request = Unirest::put($queryUrl, $headers, NULL, Configuration::$BasicAuthUserName, Configuration::$BasicAuthPassword);
+        $request = Unirest::put($queryUrl, $headers, NULL, $this->basicAuthUserName, $this->basicAuthPassword);
 
         //and invoke the API call request to fetch the response
         $response = $request->getResponse();
@@ -366,7 +366,7 @@ class RegulationController {
         );
 
         //prepare API request
-        $request = Unirest::get($queryUrl, $headers, NULL, Configuration::$BasicAuthUserName, Configuration::$BasicAuthPassword);
+        $request = Unirest::get($queryUrl, $headers, NULL, $this->basicAuthUserName, $this->basicAuthPassword);
 
         //and invoke the API call request to fetch the response
         $response = $request->getResponse();
@@ -407,7 +407,7 @@ class RegulationController {
         );
 
         //prepare API request
-        $request = Unirest::put($queryUrl, $headers, NULL, Configuration::$BasicAuthUserName, Configuration::$BasicAuthPassword);
+        $request = Unirest::put($queryUrl, $headers, NULL, $this->basicAuthUserName, $this->basicAuthPassword);
 
         //and invoke the API call request to fetch the response
         $response = $request->getResponse();


### PR DESCRIPTION
This change causes credentials passed to controller constructors to actually get used. When values are not provided in the constructor call, the values in Configuration will be used as a fallback.