### PR TITLE
Use tagged version of apimatic/unirest-php

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "ext-curl": "*",
         "ext-json": "*",
         "ext-mbstring": "*",
-        "apimatic/unirest-php": "dev-master"
+        "apimatic/unirest-php": "~1.3"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
The dependency on apimatic/unirest-php should use a tagged version, rather than relying on dev-master.

This saves applications which use this client having to allow packages with stability dev.
