### PR TITLE
Full response is now returned for all methods.

### DIFF
--- a/src/Controllers/CdrsController.php
+++ b/src/Controllers/CdrsController.php
@@ -54,7 +54,7 @@ class CdrsController {
             throw new APIException("HTTP Response Not OK", $response->code);
         }
 
-        return $response->body;
+        return $response;
     }
         
     /**
@@ -88,7 +88,7 @@ class CdrsController {
             throw new APIException("HTTP Response Not OK", $response->code);
         }
 
-        return $response->body;
+        return $response;
     }
         
     /**
@@ -128,7 +128,7 @@ class CdrsController {
             throw new APIException("HTTP Response Not OK", $response->code);
         }
 
-        return $response->body;
+        return $response;
     }
         
 }

--- a/src/Controllers/ConfigurationController.php
+++ b/src/Controllers/ConfigurationController.php
@@ -47,7 +47,7 @@ class ConfigurationController {
             throw new APIException("HTTP Response Not OK", $response->code);
         }
 
-        return $response->body;
+        return $response;
     }
         
     /**
@@ -97,7 +97,7 @@ class ConfigurationController {
             throw new APIException("HTTP Response Not OK", $response->code);
         }
 
-        return $response->body;
+        return $response;
     }
         
     /**
@@ -134,7 +134,7 @@ class ConfigurationController {
             throw new APIException("HTTP Response Not OK", $response->code);
         }
 
-        return $response->body;
+        return $response;
     }
         
     /**
@@ -176,7 +176,7 @@ class ConfigurationController {
             throw new APIException("HTTP Response Not OK", $response->code);
         }
 
-        return $response->body;
+        return $response;
     }
         
     /**
@@ -232,7 +232,7 @@ class ConfigurationController {
             throw new APIException("HTTP Response Not OK", $response->code);
         }
 
-        return $response->body;
+        return $response;
     }
         
     /**
@@ -269,7 +269,7 @@ class ConfigurationController {
             throw new APIException("HTTP Response Not OK", $response->code);
         }
 
-        return $response->body;
+        return $response;
     }
         
     /**
@@ -311,7 +311,7 @@ class ConfigurationController {
             throw new APIException("HTTP Response Not OK", $response->code);
         }
 
-        return $response->body;
+        return $response;
     }
         
     /**
@@ -367,7 +367,7 @@ class ConfigurationController {
             throw new APIException("HTTP Response Not OK", $response->code);
         }
 
-        return $response->body;
+        return $response;
     }
         
     /**
@@ -404,7 +404,7 @@ class ConfigurationController {
             throw new APIException("HTTP Response Not OK", $response->code);
         }
 
-        return $response->body;
+        return $response;
     }
         
     /**
@@ -446,7 +446,7 @@ class ConfigurationController {
             throw new APIException("HTTP Response Not OK", $response->code);
         }
 
-        return $response->body;
+        return $response;
     }
         
     /**
@@ -480,7 +480,7 @@ class ConfigurationController {
             throw new APIException("HTTP Response Not OK", $response->code);
         }
 
-        return $response->body;
+        return $response;
     }
         
     /**
@@ -514,7 +514,7 @@ class ConfigurationController {
             throw new APIException("HTTP Response Not OK", $response->code);
         }
 
-        return $response->body;
+        return $response;
     }
         
     /**
@@ -551,7 +551,7 @@ class ConfigurationController {
             throw new APIException("HTTP Response Not OK", $response->code);
         }
 
-        return $response->body;
+        return $response;
     }
         
     /**
@@ -594,7 +594,7 @@ class ConfigurationController {
             throw new APIException("HTTP Response Not OK", $response->code);
         }
 
-        return $response->body;
+        return $response;
     }
         
     /**
@@ -644,7 +644,7 @@ class ConfigurationController {
             throw new APIException("HTTP Response Not OK", $response->code);
         }
 
-        return $response->body;
+        return $response;
     }
         
     /**
@@ -681,7 +681,7 @@ class ConfigurationController {
             throw new APIException("HTTP Response Not OK", $response->code);
         }
 
-        return $response->body;
+        return $response;
     }
         
     /**
@@ -723,7 +723,7 @@ class ConfigurationController {
             throw new APIException("HTTP Response Not OK", $response->code);
         }
 
-        return $response->body;
+        return $response;
     }
         
     /**
@@ -764,7 +764,7 @@ class ConfigurationController {
             throw new APIException("HTTP Response Not OK", $response->code);
         }
 
-        return $response->body;
+        return $response;
     }
         
     /**
@@ -805,7 +805,7 @@ class ConfigurationController {
             throw new APIException("HTTP Response Not OK", $response->code);
         }
 
-        return $response->body;
+        return $response;
     }
         
     /**
@@ -846,7 +846,7 @@ class ConfigurationController {
             throw new APIException("HTTP Response Not OK", $response->code);
         }
 
-        return $response->body;
+        return $response;
     }
         
     /**
@@ -887,7 +887,7 @@ class ConfigurationController {
             throw new APIException("HTTP Response Not OK", $response->code);
         }
 
-        return $response->body;
+        return $response;
     }
         
     /**
@@ -928,7 +928,7 @@ class ConfigurationController {
             throw new APIException("HTTP Response Not OK", $response->code);
         }
 
-        return $response->body;
+        return $response;
     }
         
 }

--- a/src/Controllers/InventoryController.php
+++ b/src/Controllers/InventoryController.php
@@ -99,7 +99,7 @@ class InventoryController {
             throw new APIException("HTTP Response Not OK", $response->code);
         }
 
-        return $response->body;
+        return $response;
     }
         
     /**
@@ -133,7 +133,7 @@ class InventoryController {
             throw new APIException("HTTP Response Not OK", $response->code);
         }
 
-        return $response->body;
+        return $response;
     }
         
     /**
@@ -201,7 +201,7 @@ class InventoryController {
             throw new APIException("HTTP Response Not OK", $response->code);
         }
 
-        return $response->body;
+        return $response;
     }
         
     /**
@@ -242,7 +242,7 @@ class InventoryController {
             throw new APIException("HTTP Response Not OK", $response->code);
         }
 
-        return $response->body;
+        return $response;
     }
         
     /**
@@ -283,7 +283,7 @@ class InventoryController {
             throw new APIException("HTTP Response Not OK", $response->code);
         }
 
-        return $response->body;
+        return $response;
     }
         
     /**
@@ -317,7 +317,7 @@ class InventoryController {
             throw new APIException("HTTP Response Not OK", $response->code);
         }
 
-        return $response->body;
+        return $response;
     }
         
     /**
@@ -351,7 +351,7 @@ class InventoryController {
             throw new APIException("HTTP Response Not OK", $response->code);
         }
 
-        return $response->body;
+        return $response;
     }
         
     /**
@@ -385,7 +385,7 @@ class InventoryController {
             throw new APIException("HTTP Response Not OK", $response->code);
         }
 
-        return $response->body;
+        return $response;
     }
         
     /**
@@ -435,7 +435,7 @@ class InventoryController {
             throw new APIException("HTTP Response Not OK", $response->code);
         }
 
-        return $response->body;
+        return $response;
     }
         
     /**
@@ -476,7 +476,7 @@ class InventoryController {
             throw new APIException("HTTP Response Not OK", $response->code);
         }
 
-        return $response->body;
+        return $response;
     }
         
 }

--- a/src/Controllers/OrderingController.php
+++ b/src/Controllers/OrderingController.php
@@ -44,7 +44,7 @@ class OrderingController {
             throw new APIException("HTTP Response Not OK", $response->code);
         }
 
-        return $response->body;
+        return $response;
     }
         
     /**
@@ -81,7 +81,7 @@ class OrderingController {
             throw new APIException("HTTP Response Not OK", $response->code);
         }
 
-        return $response->body;
+        return $response;
     }
         
     /**
@@ -125,7 +125,7 @@ class OrderingController {
             throw new APIException("HTTP Response Not OK", $response->code);
         }
 
-        return $response->body;
+        return $response;
     }
         
     /**
@@ -172,7 +172,7 @@ class OrderingController {
             throw new APIException("HTTP Response Not OK", $response->code);
         }
 
-        return $response->body;
+        return $response;
     }
         
     /**
@@ -219,7 +219,7 @@ class OrderingController {
             throw new APIException("HTTP Response Not OK", $response->code);
         }
 
-        return $response->body;
+        return $response;
     }
         
     /**
@@ -261,7 +261,7 @@ class OrderingController {
             throw new APIException("HTTP Response Not OK", $response->code);
         }
 
-        return $response->body;
+        return $response;
     }
         
     /**
@@ -302,7 +302,7 @@ class OrderingController {
             throw new APIException("HTTP Response Not OK", $response->code);
         }
 
-        return $response->body;
+        return $response;
     }
         
     /**
@@ -361,7 +361,7 @@ class OrderingController {
             throw new APIException("HTTP Response Not OK", $response->code);
         }
 
-        return $response->body;
+        return $response;
     }
         
     /**
@@ -398,7 +398,7 @@ class OrderingController {
             throw new APIException("HTTP Response Not OK", $response->code);
         }
 
-        return $response->body;
+        return $response;
     }
         
     /**
@@ -439,7 +439,7 @@ class OrderingController {
             throw new APIException("HTTP Response Not OK", $response->code);
         }
 
-        return $response->body;
+        return $response;
     }
         
     /**
@@ -480,7 +480,7 @@ class OrderingController {
             throw new APIException("HTTP Response Not OK", $response->code);
         }
 
-        return $response->body;
+        return $response;
     }
         
 }

--- a/src/Controllers/RegulationController.php
+++ b/src/Controllers/RegulationController.php
@@ -58,7 +58,7 @@ class RegulationController {
         if (($response->code < 200) || ($response->code > 206)) { //[200,206] = HTTP OK
             throw new APIException("HTTP Response Not OK", $response->code);
         }
-        return $response->body;
+        return $response;
     }
         
         
@@ -101,7 +101,7 @@ class RegulationController {
             throw new APIException("HTTP Response Not OK", $response->code);
         }
 
-        return $response->body;
+        return $response;
     }
         
     /**
@@ -142,7 +142,7 @@ class RegulationController {
             throw new APIException("HTTP Response Not OK", $response->code);
         }
 
-        return $response->body;
+        return $response;
     }
         
     /**
@@ -219,7 +219,7 @@ class RegulationController {
             throw new APIException("HTTP Response Not OK", $response->code);
         }
 
-        return $response->body;
+        return $response;
     }
         
     /**
@@ -263,7 +263,7 @@ class RegulationController {
             throw new APIException("HTTP Response Not OK", $response->code);
         }
 
-        return $response->body;
+        return $response;
     }
         
     /**
@@ -300,7 +300,7 @@ class RegulationController {
             throw new APIException("HTTP Response Not OK", $response->code);
         }
 
-        return $response->body;
+        return $response;
     }
         
     /**
@@ -349,7 +349,7 @@ class RegulationController {
             throw new APIException("HTTP Response Not OK", $response->code);
         }
 
-        return $response->body;
+        return $response;
     }
         
      /**
@@ -394,7 +394,7 @@ class RegulationController {
         if (($response->code < 200) || ($response->code > 206)) { //[200,206] = HTTP OK
             throw new APIException("HTTP Response Not OK", $response->code);
         }
-        return $response->body;
+        return $response;
     }
 
         
@@ -437,7 +437,7 @@ class RegulationController {
             throw new APIException("HTTP Response Not OK", $response->code);
         }
 
-        return $response->body;
+        return $response;
     }
         
     /**
@@ -488,7 +488,7 @@ class RegulationController {
             throw new APIException("HTTP Response Not OK", $response->code);
         }
 
-        return $response->body;
+        return $response;
     }
         
 }


### PR DESCRIPTION
All methods were returning only body of the response. Often the body comes out broken by missing first several characters. It happens because wrong header size is returned by curl and it's being relied on to split the response correctly.

Also, having the full response is more practical by giving a lot more options and potential for building wrappers around the API client.